### PR TITLE
Loosen momentjs dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "angular": "~1.2",
     "angular-bindonce": "*",
-    "moment": "~2.6.0",
+    "moment": "^2.6.0",
     "moment-range": "~1.0.1"
   },
   "license": "MIT",


### PR DESCRIPTION
Version `~2.6.0` means `>= 2.6.0 < 2.7.0` which is too strict I think
(see [2.7.0 Changlelog](https://github.com/moment/moment/blob/develop/CHANGELOG.md#270-see-changelog)).

Version `^2.6.0` means `>= 2.6.0 < 3.0.0`.
